### PR TITLE
Case 26687

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
     ],
 
     "extra": {
-        "enable-patching" : true,
         "patches": {
             "drupal/core": {
                 "Allow installing new sites with exported configuration": "https://www.drupal.org/files/issues/1613424-2-71.patch"
@@ -31,7 +30,6 @@
 
     "require": {
         "drupal/core": "^8.1.8",
-        "cweagans/composer-patches": "@dev",
         "drupal/ctools": "3.0-alpha26",
         "drupal/config_update": "^1.1",
         "drupal/metatag": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,9 @@
 
     "extra": {
         "patches": {
+            "drupal/core": {
+                "Allow installing new sites with exported configuration": "https://www.drupal.org/files/issues/1613424-2-71.patch"
+            }
         }
     },
 
@@ -26,7 +29,7 @@
     },
 
     "require": {
-        "drupal/core": "^8.1.0",
+        "drupal/core": "^8.1.8",
         "drupal/ctools": "3.0-alpha26",
         "drupal/config_update": "^1.1",
         "drupal/metatag": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     ],
 
     "extra": {
+        "enable-patching" : true,
         "patches": {
             "drupal/core": {
                 "Allow installing new sites with exported configuration": "https://www.drupal.org/files/issues/1613424-2-71.patch"
@@ -30,7 +31,7 @@
 
     "require": {
         "drupal/core": "^8.1.8",
-        "cweagans/composer-patches": "^1.5.0",
+        "cweagans/composer-patches": "@dev",
         "drupal/ctools": "3.0-alpha26",
         "drupal/config_update": "^1.1",
         "drupal/metatag": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
 
     "require": {
         "drupal/core": "^8.1.8",
+        "cweagans/composer-patches": "^1.5.0",
         "drupal/ctools": "3.0-alpha26",
         "drupal/config_update": "^1.1",
         "drupal/metatag": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -3,15 +3,6 @@
     "description": "Drupal Distro Profile",
     "type": "drupal-profile",
     "license": "GPL-2.0+",
-    "minimum-stability": "dev",
-    "prefer-stable": true,
-
-    "repositories": [
-        {
-            "type": "composer",
-            "url": "https://packages.drupal.org/8"
-        }
-    ],
 
     "extra": {
         "patches": {
@@ -19,13 +10,6 @@
                 "Allow installing new sites with exported configuration": "https://www.drupal.org/files/issues/1613424-2-71.patch"
             }
         }
-    },
-
-    "require-dev": {
-        "drush/drush": "^9.0",
-        "phpunit/phpunit": "~4.8",
-        "squizlabs/php_codesniffer": "2.*",
-        "drupal/devel": "^1.0"
     },
 
     "require": {

--- a/dennis_profile.info.yml
+++ b/dennis_profile.info.yml
@@ -4,9 +4,6 @@ description: 'Build a custom site without pre-configured functionality. Suitable
 version: VERSION
 core: 8.x
 
-distribution:
-  name: Dennis
-
 dependencies:
   - site_core
   - node


### PR DESCRIPTION
These changed are needed to make composer download all requirements properly and apply the patch to Drupal core that adds Configuration Installer functionality, used to spin sites from the scratch without a DB dump. It is also useful to copy functionalities from other sites.
