### PR TITLE
Adding file_entity module to export files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "drupal/core": "^8.1.8",
         "drupal/ctools": "3.0-alpha26",
         "drupal/config_update": "^1.1",
+        "drupal/file_entity": "^2.0",
         "drupal/metatag": "^1.0",
         "drupal/token": "^1.0",
         "drupal/pathauto": "^1.0",


### PR DESCRIPTION
To export files with the default_content module they need to be full entities, this module is required.