### PR TITLE
266990 gtm

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         },
         {
             "type": "vcs",
+            "vendor-alias": "dennisdigital",
             "url": "git@github.com:dennisinteractive/google_tag.git"
         }
     ],

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         },
         {
             "type": "vcs",
-            "url": "git@github.com:dennisinteractive/google_tag.git"
+            "url": "https://github.com/dennisinteractive/google_tag"
         }
     ],
 

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "drupal/metatag": "^1.0",
         "drupal/token": "^1.0",
         "drupal/pathauto": "^1.0",
-        "drupal/google_tag": "dev-dennis-8.x-1.x#66c4b40247dfcbc895cc544f62ca9a8be9fcc6f9",
+        "drupal/google_tag": "dev-dennis-8.x-1.x",
         "drupal/diff": "^1.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "drupal/metatag": "^1.0",
         "drupal/token": "^1.0",
         "drupal/pathauto": "^1.0",
-        "drupal/google_tag": "dev-dennis-8.x-1.x#66c4b40247dfcbc895cc544f62ca9a8be9fcc6f9",
+        "dennisdigital/google_tag": "dev-dennis-8.x-1.x#66c4b40247dfcbc895cc544f62ca9a8be9fcc6f9",
         "drupal/diff": "^1.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "drupal/metatag": "^1.0",
         "drupal/token": "^1.0",
         "drupal/pathauto": "^1.0",
-        "drupal/google_tag": "dev-dennis-8.x-1.x#66c4b40247dfcbc895cc544f62ca9a8be9fcc6f9",
+        "drupal/google_tag": "dennis-8.x-1.x-dev#66c4b40247dfcbc895cc544f62ca9a8be9fcc6f9",
         "drupal/diff": "^1.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "drupal/metatag": "^1.0",
         "drupal/token": "^1.0",
         "drupal/pathauto": "^1.0",
-        "drupal/google_tag": "dev-dennis-8.x-1.x",
+        "solotandem/google_tag": "dev-dennis-8.x-1.x#66c4b40247dfcbc895cc544f62ca9a8be9fcc6f9"
         "drupal/diff": "^1.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
         },
         {
             "type": "vcs",
-            "vendor-alias": "dennisdigital",
             "url": "git@github.com:dennisinteractive/google_tag.git"
         }
     ],
@@ -36,7 +35,7 @@
         "drupal/metatag": "^1.0",
         "drupal/token": "^1.0",
         "drupal/pathauto": "^1.0",
-        "dennisdigital/google_tag": "dev-dennis-8.x-1.x#66c4b40247dfcbc895cc544f62ca9a8be9fcc6f9",
+        "drupal/google_tag": "dev-dennis-8.x-1.x#66c4b40247dfcbc895cc544f62ca9a8be9fcc6f9",
         "drupal/diff": "^1.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         },
         {
             "type": "vcs",
-            "url": "https://github.com/dennisinteractive/google_tag"
+            "url": "git@github.com:dennisinteractive/google_tag.git",
+            "no-api": true
         }
     ],
 
@@ -35,7 +36,7 @@
         "drupal/metatag": "^1.0",
         "drupal/token": "^1.0",
         "drupal/pathauto": "^1.0",
-        "drupal/google_tag": "dev-dennis-8.x-1.x#66c4b40247dfcbc895cc544f62ca9a8be9fcc6f9",
+        "drupal/google_tag": "dev-dennis-8.x-1.x"
         "drupal/diff": "^1.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "drupal/metatag": "^1.0",
         "drupal/token": "^1.0",
         "drupal/pathauto": "^1.0",
-        "solotandem/google_tag": "dev-dennis-8.x-1.x#66c4b40247dfcbc895cc544f62ca9a8be9fcc6f9",
+        "drupal/google_tag": "dev-dennis-8.x-1.x#66c4b40247dfcbc895cc544f62ca9a8be9fcc6f9",
         "drupal/diff": "^1.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "drupal/metatag": "^1.0",
         "drupal/token": "^1.0",
         "drupal/pathauto": "^1.0",
-        "drupal/google_tag": "dev-dennis-8.x-1.x",
+        "drupal/google_tag": "dev-dennis-8.x-1.x#66c4b40247dfcbc895cc544f62ca9a8be9fcc6f9",
         "drupal/diff": "^1.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "drupal/metatag": "^1.0",
         "drupal/token": "^1.0",
         "drupal/pathauto": "^1.0",
-        "drupal/google_tag": "dennis-8.x-1.x-dev#66c4b40247dfcbc895cc544f62ca9a8be9fcc6f9",
+        "drupal/google_tag": "dev-dennis-8.x-1.x#66c4b40247dfcbc895cc544f62ca9a8be9fcc6f9",
         "drupal/diff": "^1.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "drupal/metatag": "^1.0",
         "drupal/token": "^1.0",
         "drupal/pathauto": "^1.0",
-        "drupal/google_tag": "dev-dennis-8.x-1.x"
+        "drupal/google_tag": "dev-dennis-8.x-1.x",
         "drupal/diff": "^1.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "drupal/metatag": "^1.0",
         "drupal/token": "^1.0",
         "drupal/pathauto": "^1.0",
-        "solotandem/google_tag": "dev-dennis-8.x-1.x#66c4b40247dfcbc895cc544f62ca9a8be9fcc6f9"
+        "solotandem/google_tag": "dev-dennis-8.x-1.x#66c4b40247dfcbc895cc544f62ca9a8be9fcc6f9",
         "drupal/diff": "^1.0"
     }
 }


### PR DESCRIPTION
Due to a vendor name problem in the original name we still need to keep 
` "solotandem/google_tag": "dev-dennis-8.x-1.x#66c4b40247dfcbc895cc544f62ca9a8be9fcc6f9",
`

once this has been solved in the origin we'll be able to change it to drupal/google_tag.

I've tried few workarounds but it didn't do the trick.

An issue has been open and acepted here https://www.drupal.org/node/2845873
It only needs for the maintainer to merge to the branch.